### PR TITLE
CRNCC-2064 - Back link to previous page not working as expected

### DIFF
--- a/BPOR/BPOR.Rms/Controllers/FilterController.cs
+++ b/BPOR/BPOR.Rms/Controllers/FilterController.cs
@@ -23,8 +23,6 @@ public class FilterController(ParticipantDbContext context,
         bool isResearcher = currentUserProvider?.User?.UserRoles.Any(r => r.RoleId == (int)Domain.Enums.UserRole.Researcher) ?? false;
         if (isResearcher)
         {
-            ViewData["BackLinkURL"] = HttpContext.Request.Headers["Referer"].ToString();
-            ViewData["ShowBackLink"] = true;
             return View("Unauthorised");
         }
         FilterResults results = new();

--- a/BPOR/BPOR.Rms/Controllers/ResearcherController.cs
+++ b/BPOR/BPOR.Rms/Controllers/ResearcherController.cs
@@ -33,7 +33,6 @@ public class ResearcherController(ParticipantDbContext context, ICurrentUserProv
 
     public IActionResult SubmitStudy(ResearcherStudyFormViewModel model)
     {
-        ViewData["ShowProgressBar"] = true;
         ViewData["ProgressPercentage"] = 0;
 
         return View(model);
@@ -42,7 +41,6 @@ public class ResearcherController(ParticipantDbContext context, ICurrentUserProv
     [HttpPost]
     public async Task<IActionResult> SubmitStudy(ResearcherStudyFormViewModel model, string action)
     {
-        ViewData["ShowProgressBar"] = true;
         ViewData["ProgressPercentage"] = (model.Step - 1) * 15;
 
         model.PortfolioSubmissionStatusOptions = context.Submitted.ToList();
@@ -54,7 +52,7 @@ public class ResearcherController(ParticipantDbContext context, ICurrentUserProv
             if (ModelState.IsValid)
             {
                 model.Step = 8;
-                ViewData["ShowProgressBar"] = false;
+                ViewData["ProgressPercentage"] = null;
                 model.RedirectToCheckYourAnswers = false;
             }
             return View(model);
@@ -200,7 +198,7 @@ public class ResearcherController(ParticipantDbContext context, ICurrentUserProv
             if (ModelState.IsValid)
             {
                 model.Step = 8;
-                ViewData["ShowProgressBar"] = false;
+                ViewData["ProgressPercentage"] = null;
                 return View(model);
             }
         }

--- a/BPOR/BPOR.Rms/Controllers/ResearcherController.cs
+++ b/BPOR/BPOR.Rms/Controllers/ResearcherController.cs
@@ -1,45 +1,15 @@
 using BPOR.Domain.Entities;
-using BPOR.Domain.Entities.RefData;
 using BPOR.Rms.Models;
-using BPOR.Rms.Models.Email;
 using BPOR.Rms.Models.Researcher;
 using BPOR.Rms.Models.Study;
 using BPOR.Rms.Startup;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
 
 namespace BPOR.Rms.Controllers;
 
 public class ResearcherController(ParticipantDbContext context, ICurrentUserProvider<User> currentUserProvider) : Controller
 {
-    public IActionResult Create()
-    {
-        ViewData["BackLinkURL"] = HttpContext.Request.Headers["Referer"].ToString();
-        ViewData["ShowBackLink"] = true;
-        return View(new ResearcherFormViewModel());
-    }
-    
-
-    [HttpPost]
-    public IActionResult Create(ResearcherFormViewModel model)
-    {
-        ViewData["BackLinkURL"] = HttpContext.Request.Headers["Referer"].ToString();
-        ViewData["ShowBackLink"] = true;
-
-        if (model.Password?.Length < 12)
-        {
-            ModelState.AddModelError("Password", "Enter a password that is at least 12 characters long and does not include any symbols");
-        }
-
-        if (ModelState.IsValid)
-        {
-            return View("AddResearcherSuccess");
-        }
-
-        return View(model);
-    }
-
     public IActionResult TermsAndConditions()
     {
         return View(new ResearcherTermsAndConditionsViewModel());

--- a/BPOR/BPOR.Rms/TagHelpers/BackLinkTagHelper.cs
+++ b/BPOR/BPOR.Rms/TagHelpers/BackLinkTagHelper.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Text.Encodings.Web;
+
+namespace BPOR.Rms.TagHelpers
+{
+    public class BackLinkTagHelper(IHtmlGenerator generator) : TagHelper
+    {
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; } = null!;
+
+        public override int Order => 100;
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            var referer = ViewContext.HttpContext.Request.Headers.Referer.FirstOrDefault();
+            var showBackLink = ViewContext.ViewData.IsBackLinkEnabled();
+            if (ViewContext.ViewData["_BackLinkForm"] is not null)
+            {
+                var formId = ViewContext.ViewData["_BackLinkForm"] as string;
+                var modelExpression = ViewContext.ViewData["_BackLinkFor"] as ModelExpression;
+                var backValue = ViewContext.ViewData["_BackLinkForValue"];
+
+                var hiddenElement = generator.GenerateHidden(ViewContext, modelExpression.ModelExplorer, modelExpression.Name, backValue, false, null);
+
+                output.TagName = "button";
+                output.TagMode = TagMode.StartTagAndEndTag;
+
+                output.AddClass("govuk-back-link", HtmlEncoder.Default);
+                output.Attributes.SetAttribute("form", formId);
+                output.Attributes.SetAttribute("type", "submit");
+                output.Attributes.SetAttribute("name", hiddenElement.Attributes["name"]);
+                output.Attributes.SetAttribute("value", hiddenElement.Attributes["value"]);
+                output.Content.SetContent("Back");
+            }
+            else if (referer != null && showBackLink == true)
+            {
+                output.TagName = "a";
+                output.TagMode = TagMode.StartTagAndEndTag;
+
+                output.AddClass("govuk-back-link", HtmlEncoder.Default);
+                output.AddClass("govuk-link", HtmlEncoder.Default);
+                output.Attributes.SetAttribute("href", referer);
+
+                output.Content.SetContent("Back");
+            }
+            else
+            {
+                output.SuppressOutput();
+            }
+        }
+    }
+}

--- a/BPOR/BPOR.Rms/TagHelpers/BackLinkTagHelper.cs
+++ b/BPOR/BPOR.Rms/TagHelpers/BackLinkTagHelper.cs
@@ -33,7 +33,7 @@ namespace BPOR.Rms.TagHelpers
                 output.Attributes.SetAttribute("form", formId);
                 output.Attributes.SetAttribute("type", "submit");
                 output.Attributes.SetAttribute("name", hiddenElement.Attributes["name"]);
-                output.Attributes.SetAttribute("value", hiddenElement.Attributes["value"]);
+                output.Attributes.SetAttribute("value", backValue);
                 output.Content.SetContent("Back");
             }
             else if (referer != null && showBackLink == true)

--- a/BPOR/BPOR.Rms/TagHelpers/WithBackLinkTagHelper.cs
+++ b/BPOR/BPOR.Rms/TagHelpers/WithBackLinkTagHelper.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace BPOR.Rms.TagHelpers
+{
+    [HtmlTargetElement(Attributes = "back-link-for")]
+    public class WithBackLinkTagHelper : TagHelper
+    {
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; } = null!;
+
+        public ModelExpression BackLinkFor { get; set; }
+
+        public object BackLinkForValue { get; set; }
+
+        public override int Order => 50;
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            var formId = context.UniqueId;
+            if (context.AllAttributes.ContainsName("id"))
+            {
+                formId = context.AllAttributes["id"].Value.ToString();
+            }
+            else
+            {
+                output.Attributes.Add("id", formId);
+            }
+
+            ViewContext.ViewData.ShowBackLink();
+            ViewContext.ViewData["_BackLinkForm"] = formId;
+            ViewContext.ViewData["_BackLinkFor"] = BackLinkFor;
+            ViewContext.ViewData["_BackLinkForValue"] = BackLinkForValue;
+        }
+    }
+}

--- a/BPOR/BPOR.Rms/ViewDataExtensions.cs
+++ b/BPOR/BPOR.Rms/ViewDataExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace BPOR.Rms
+{
+    public static class ViewDataExtensions
+    {
+        public static void ShowBackLink(this ViewDataDictionary viewData, bool? showBackLink = true)
+        {
+            viewData["ShowBackLink"] = showBackLink;
+        }
+
+        public static bool? IsBackLinkEnabled(this ViewDataDictionary viewData)
+        {
+            return viewData["ShowBackLink"] as bool?;
+        }
+    }
+}

--- a/BPOR/BPOR.Rms/Views/Account/Create.cshtml
+++ b/BPOR/BPOR.Rms/Views/Account/Create.cshtml
@@ -2,9 +2,8 @@
 
 @{
     ViewData["Title"] = "What is your email address?";
+    ViewData.ShowBackLink();
 }
-
-<a href="~/" class="govuk-back-link">Back</a>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">

--- a/BPOR/BPOR.Rms/Views/Filter/Index.cshtml
+++ b/BPOR/BPOR.Rms/Views/Filter/Index.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewData["Title"] = "Find volunteers";
+    ViewData.ShowBackLink();
 
     if (Model.VolunteerCount is not null)
     {

--- a/BPOR/BPOR.Rms/Views/Researcher/SubmitStudy.cshtml
+++ b/BPOR/BPOR.Rms/Views/Researcher/SubmitStudy.cshtml
@@ -6,15 +6,6 @@
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
-@if (ViewData["ShowProgressBar"] != null && (bool)ViewData["ShowProgressBar"])
-{
-    @section ProgressBar {
-    @await Html.PartialAsync("Partials/_ProgressBar", Model)
-    }
-}
-
-
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-grid-column-one-half-from-desktop">
 

--- a/BPOR/BPOR.Rms/Views/Shared/Partials/_ProgressBar.cshtml
+++ b/BPOR/BPOR.Rms/Views/Shared/Partials/_ProgressBar.cshtml
@@ -13,5 +13,5 @@
 </style>
 
 <div class="progress-bar-container" aria-labelledby="form-progress">
-    <div id="form-progress" class="progress-bar" style="width: @((Model.Step - 1) / (double)Model.TotalSteps * 100)%;"></div>
+    <div id="form-progress" class="progress-bar" style="width: @(ViewData["ProgressPercentage"])%;"></div>
 </div>

--- a/BPOR/BPOR.Rms/Views/Shared/Partials/_ProgressBar.cshtml
+++ b/BPOR/BPOR.Rms/Views/Shared/Partials/_ProgressBar.cshtml
@@ -1,5 +1,3 @@
-@model  dynamic
-
 <style>
     .progress-bar-container {
         width: 100%;

--- a/BPOR/BPOR.Rms/Views/Shared/Unauthorised.cshtml
+++ b/BPOR/BPOR.Rms/Views/Shared/Unauthorised.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     ViewData["Title"] = "Unauthorised";
     Layout = "~/Views/Shared/_Layout.cshtml";
+    ViewData.ShowBackLink();
 }
 
 <div class="govuk-grid-row">

--- a/BPOR/BPOR.Rms/Views/Shared/_Layout.cshtml
+++ b/BPOR/BPOR.Rms/Views/Shared/_Layout.cshtml
@@ -29,14 +29,14 @@
 
     <partial name="_Header" />
 
-    @if (ViewData["ShowProgressBar"] as bool? ?? false)
+    @if (ViewData["ProgressPercentage"] is not null)
     {
-        @await RenderSectionAsync("ProgressBar", required: false)
+        <partial name="Partials/_ProgressBar" />
     }
 
     <div class="govuk-width-container">
         <div class="govuk-back-link-container float-content-right">
-                @if (ViewData["ShowProgressBar"] as bool? ?? false)
+            @if (ViewData["ProgressPercentage"] is not null)
                 {
                     <span class="govuk-progress-percentage">@ViewData["ProgressPercentage"]%</span>
                 }

--- a/BPOR/BPOR.Rms/Views/Shared/_Layout.cshtml
+++ b/BPOR/BPOR.Rms/Views/Shared/_Layout.cshtml
@@ -34,31 +34,14 @@
         @await RenderSectionAsync("ProgressBar", required: false)
     }
 
-    @{
-        bool showBackLink = ViewData["ShowBackLink"] as bool? ?? false;
-        string backLink = ViewData["BackLinkURL"] as string ?? "";
-    }
-
     <div class="govuk-width-container">
-
-        <div class="govuk-back-link-container @(showBackLink ? "" : "float-content-right")">
-                @if (showBackLink)
-                {
-                    if (!String.IsNullOrEmpty(backLink))
-                    {
-                        <a class="govuk-back-link" href="@backLink">Back</a>
-                    }
-                    else
-                    {
-                        <a href="#" class="govuk-back-link" onclick="window.history.back()">Back</a>
-                    }          
-                }
+        <div class="govuk-back-link-container float-content-right">
                 @if (ViewData["ShowProgressBar"] as bool? ?? false)
                 {
                     <span class="govuk-progress-percentage">@ViewData["ProgressPercentage"]%</span>
                 }
         </div>
-
+        <back-link />
         <main class="govuk-main-wrapper" id="main-content" role="main">
             <breadcrumbs />
             <partial name="Partials/_NotificationBanner" />

--- a/BPOR/BPOR.Rms/Views/Study/Create.cshtml
+++ b/BPOR/BPOR.Rms/Views/Study/Create.cshtml
@@ -18,7 +18,7 @@
     <div class="govuk-grid-column-two-thirds govuk-grid-column-one-half-from-desktop">
         <h1 class="govuk-heading-xl">Add a study to use the Be Part of Research registry</h1>
 
-        <form asp-action="Create">
+        <form asp-action="Create" back-link-for="Step" back-link-for-value="@(Model.Step-1)">
             <input type="hidden" asp-for="Step" value="@Model.Step"/>
 
             <div style="@(Model.Step == 1 ? "" : "display:none;")">

--- a/BPOR/BPOR.Rms/Views/Study/Create.cshtml
+++ b/BPOR/BPOR.Rms/Views/Study/Create.cshtml
@@ -1,35 +1,26 @@
 @model BPOR.Rms.Models.Study.StudyFormViewModel
 
-<style>
-
-</style>
-
 @{
     ViewData["Title"] = "Add a study";
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
-
-@section ProgressBar {
-    <partial name="Partials/_ProgressBar" />
-}
-
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-grid-column-one-half-from-desktop">
         <h1 class="govuk-heading-xl">Add a study to use the Be Part of Research registry</h1>
 
         <form asp-action="Create" back-link-for="Step" back-link-for-value="@(Model.Step-1)">
-            <input type="hidden" asp-for="Step" value="@Model.Step"/>
+            <input type="hidden" asp-for="Step" value="@Model.Step" />
 
             <div style="@(Model.Step == 1 ? "" : "display:none;")">
-                <partial name="Partials/Shared/_Step1FormFields"/>
+                <partial name="Partials/Shared/_Step1FormFields" />
             </div>
 
             <div style="@(Model.Step == 2 ? "" : "display:none;")">
-                <partial name="Partials/Shared/_Step2FormFields"/>
+                <partial name="Partials/Shared/_Step2FormFields" />
             </div>
 
-            <partial name="Partials/_CreateButtonGroup"/>
+            <partial name="Partials/_CreateButtonGroup" />
         </form>
 
     </div>

--- a/BPOR/BPOR.Rms/wwwroot/css/nihr-component-ui.css
+++ b/BPOR/BPOR.Rms/wwwroot/css/nihr-component-ui.css
@@ -254,7 +254,6 @@
     text-decoration: none;
     color: rgb(29, 112, 184);
     cursor: pointer;
-    margin-top: 0;
 }
 
     .govuk-link:hover,

--- a/BPOR/BPOR.Rms/wwwroot/css/nihr-ui.css
+++ b/BPOR/BPOR.Rms/wwwroot/css/nihr-ui.css
@@ -292,9 +292,9 @@ body {
     padding-bottom: 10px;
 }
 
-.pill-container.pill-container-column {
-    flex-direction: column;
-}
+    .pill-container.pill-container-column {
+        flex-direction: column;
+    }
 
 .pill {
     padding-top: 1px;
@@ -350,7 +350,7 @@ body {
     margin-bottom: 5px !important;
 }
 
-.govuk-skip-link.end-of-options{
+.govuk-skip-link.end-of-options {
     margin-top: 5px !important;
 }
 
@@ -358,10 +358,15 @@ body {
     margin-bottom: 5px !important;
 }
 
-.govuk-checkboxes__item.skip-link{
+.govuk-checkboxes__item.skip-link {
     margin-bottom: unset;
 }
 
-.email-address{
+.email-address {
     font-weight: bold;
+}
+
+button.govuk-back-link {
+    border: none;
+    background: none;
 }


### PR DESCRIPTION
- Created `BackLinkTagHelper` to dynamically render backlinks.
- Moved backlink out of `main` content to comply with GDS requirements.
- Backlink is hidden by default. `ViewData.ShowBackLink()` in the view causes it to be rendered as a plain `a` link pointing to the page referer.
- `WithBackLinkTagHelper` allows forms to be annotated to specify the Model property that controls the form step and the step value when Back is clicked.
- If a form is annotated `WithBackLinkTagHelper` the `BackLinkTagHelper` renders a `button` styled as a link with its `form` attribute set to the form on the main page, `action` set to `Back` and `type` set to `submit`. This allows the back link to resubmit the form and preserve the already entered information.
- The target controller action, clears validation errors on `Back` and redirects to an appropriate page when the user clicks back on the first step of the form.
- Also tidied up progress bar rendering  