### PR TITLE
CRNCC-2251 order errors in same order as page

### DIFF
--- a/BPOR/BPOR.Rms/Controllers/CreateAccountModel.cs
+++ b/BPOR/BPOR.Rms/Controllers/CreateAccountModel.cs
@@ -6,6 +6,7 @@ namespace BPOR.Rms.Controllers
     {
         [Required(ErrorMessage = "Enter your email address")]
         [EmailAddress(ErrorMessage = "Enter an email address in the correct format, like name@example.com")]
+        [Display(Order = 1)]
         public string Email { get; set; }
     }
 }

--- a/BPOR/BPOR.Rms/Controllers/GatherAccountInformationModel.cs
+++ b/BPOR/BPOR.Rms/Controllers/GatherAccountInformationModel.cs
@@ -7,15 +7,15 @@ namespace BPOR.Rms.Controllers
         [Required(ErrorMessage = "A verification code is required", AllowEmptyStrings = false)]
         public string Code { get; set; } = string.Empty;
 
-        [Display(Name = "First name")]
+        [Display(Name = "First name", Order = 1)]
         [Required(ErrorMessage = "Enter your first name")]
         public string? FirstName { get; set; }
 
-        [Display(Name = "Last name")]
+        [Display(Name = "Last name", Order = 2)]
         [Required(ErrorMessage = "Enter your last name")]
         public string? LastName { get; set; }
 
-        [Display(Name = "Password")]
+        [Display(Name = "Password", Order = 3)]
         [Required(ErrorMessage = "Enter a password")]
         [MinLength(12, ErrorMessage = "Enter a password that is at least 12 characters long")]
         public string? Password { get; set; }

--- a/BPOR/BPOR.Rms/Models/Email/SetupCampaignViewModel.cs
+++ b/BPOR/BPOR.Rms/Models/Email/SetupCampaignViewModel.cs
@@ -19,17 +19,17 @@ public class SetupCampaignViewModel
     public int FilterCriteriaId { get; set; }
 
 
-    [DisplayName("Select email template")]
+    [Display(Name = "Select email template", Order = 1)]
     public string? SelectedTemplateId { get; set; }
     public TemplateList EmailTemplates { get; set; } = new ();
 
 
-    [DisplayName("How many volunteers do you want to send it to?")]
+    [Display(Name = "How many volunteers do you want to send it to?", Order = 3)]
     [Range(1, int.MaxValue, ErrorMessage = "Total Volunteers must be at least 1.")]
     public int? TotalVolunteers { get; set; }
 
 
-    [DisplayName("Preview email")]
+    [Display(Name ="Preview email", Order = 2)]
     public string? PreviewEmails { get; set; }
     
     public IEnumerable<string> GetPreviewEmailAddresses() => PreviewEmails?.Split(_emailListDelimiters, StringSplitOptions.RemoveEmptyEntries)?.Select(x=>x.Trim()) ?? Enumerable.Empty<string>();

--- a/BPOR/BPOR.Rms/Models/Filter/PostcodeSearchModel.cs
+++ b/BPOR/BPOR.Rms/Models/Filter/PostcodeSearchModel.cs
@@ -12,9 +12,10 @@ namespace BPOR.Rms.Models.Filter
 {
     public class PostcodeSearchModel : IValidatableObject
     {
-        [Display(Name = "Postcode districts", Description = "Enter one or more postcode districts separated by commas.\r\nFor example: SW1A, WC2B, EC1V.", Order = 6)]
+        [Display(Name = "Postcode districts", Description = "Enter one or more postcode districts separated by commas.\r\nFor example: SW1A, WC2B, EC1V.", Order = 1)]
         public string? PostcodeDistricts { get; set; }
 
+        [Display(Order = 2)]
         public PostcodeRadiusSearchModel PostcodeRadiusSearch { get; set; } = new();
 
         public ISet<string> GetPostcodeDistricts() => PostcodeDistricts?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToHashSet() ?? [];
@@ -45,14 +46,14 @@ namespace BPOR.Rms.Models.Filter
 
     public class PostcodeRadiusSearchModel : IValidatableObject
     {
-        [Display(Name = "Full postcode", Description = "For example: EC1A 1BB.", Order = 7)]
+        [Display(Name = "Full postcode", Description = "For example: EC1A 1BB.", Order = 1)]
 
         public Postcode? FullPostcode { get; set; }
 
         [LookupLocation(From = nameof(FullPostcode))]
         public Point? Location { get; set; }
 
-        [Display(Name = "Radius", Description = "Indicate the radius, in miles, for searching volunteers based on the provided full postcode.", Order = 8)]
+        [Display(Name = "Radius", Description = "Indicate the radius, in miles, for searching volunteers based on the provided full postcode.", Order = 2)]
         [IntegerOrDecimal(ErrorMessage = "Enter a whole number or a positive number with one decimal place, like 8 or 1.3", RequiredIfNotNull = nameof(FullPostcode))]
         public double? SearchRadiusMiles { get; set; }
 

--- a/BPOR/BPOR.Rms/Models/Filter/PostcodeSearchModel.cs
+++ b/BPOR/BPOR.Rms/Models/Filter/PostcodeSearchModel.cs
@@ -12,7 +12,7 @@ namespace BPOR.Rms.Models.Filter
 {
     public class PostcodeSearchModel : IValidatableObject
     {
-        [Display(Name = "Postcode districts", Description = "Enter one or more postcode districts separated by commas.\r\nFor example: SW1A, WC2B, EC1V.")]
+        [Display(Name = "Postcode districts", Description = "Enter one or more postcode districts separated by commas.\r\nFor example: SW1A, WC2B, EC1V.", Order = 6)]
         public string? PostcodeDistricts { get; set; }
 
         public PostcodeRadiusSearchModel PostcodeRadiusSearch { get; set; } = new();
@@ -45,14 +45,14 @@ namespace BPOR.Rms.Models.Filter
 
     public class PostcodeRadiusSearchModel : IValidatableObject
     {
-        [Display(Name = "Full postcode", Description = "For example: EC1A 1BB.")]
+        [Display(Name = "Full postcode", Description = "For example: EC1A 1BB.", Order = 7)]
 
         public Postcode? FullPostcode { get; set; }
 
         [LookupLocation(From = nameof(FullPostcode))]
         public Point? Location { get; set; }
 
-        [Display(Name = "Radius", Description = "Indicate the radius, in miles, for searching volunteers based on the provided full postcode.")]
+        [Display(Name = "Radius", Description = "Indicate the radius, in miles, for searching volunteers based on the provided full postcode.", Order = 8)]
         [IntegerOrDecimal(ErrorMessage = "Enter a whole number or a positive number with one decimal place, like 8 or 1.3", RequiredIfNotNull = nameof(FullPostcode))]
         public double? SearchRadiusMiles { get; set; }
 

--- a/BPOR/BPOR.Rms/Models/Filter/VolunteerFilterViewModel.cs
+++ b/BPOR/BPOR.Rms/Models/Filter/VolunteerFilterViewModel.cs
@@ -18,7 +18,7 @@ public class VolunteerFilterViewModel : IValidatableObject
 
     public bool ShowRecruitedFilter { get; set; }
 
-    [Display(Name = "Volunteers contacted")]
+    [Display(Name = "Volunteers contacted", Order = 1)]
     public bool? SelectedVolunteersContacted { get; set; }
     public IEnumerable<SelectListItem> VolunteersContactedItems { get; set; } = SetVolunteersContactedItems();
 
@@ -34,7 +34,7 @@ public class VolunteerFilterViewModel : IValidatableObject
         return items;
     }
 
-    [Display(Name = "Volunteers recruited")]
+    [Display(Name = "Volunteers recruited", Order = 3)]
     public bool? SelectedVolunteersRecruited { get; set; }
     public IEnumerable<SelectListItem> VolunteersRecruitedItems { get; set; } = SetVolunteersRecruitedItems();
 
@@ -50,7 +50,7 @@ public class VolunteerFilterViewModel : IValidatableObject
         return items;
     }
 
-    [Display(Name = "Volunteers registered interest")]
+    [Display(Name = "Volunteers registered interest", Order = 2)]
     public bool? SelectedVolunteersRegisteredInterest { get; set; }
     public IEnumerable<SelectListItem> VolunteersRegisteredInterestItems { get; set; } = SetVolunteersRegisteredInterestItems();
 
@@ -66,7 +66,7 @@ public class VolunteerFilterViewModel : IValidatableObject
         return items;
     }
 
-    [Display(Name = "Volunteers completed registration")]
+    [Display(Name = "Volunteers completed registration", Order = 4)]
     public bool? SelectedVolunteersCompletedRegistration { get; set; }
     public IEnumerable<SelectListItem> VolunteersCompletedRegistrationItems { get; set; } = SetVolunteersCompletedRegistrationItems();
 
@@ -88,41 +88,41 @@ public class VolunteerFilterViewModel : IValidatableObject
 
     public bool IncludeNoAreasOfInterest { get; set; }
 
-    [Display(Name = "Date of volunteer registration (from)")]
+    [Display(Name = "Date of volunteer registration (from)", Order = 5)]
     public GovUkDate RegistrationFromDate { get; set; } = new();
 
-    [Display(Name = "Date of volunteer registration (to)")]
+    [Display(Name = "Date of volunteer registration (to)", Order = 6)]
     public GovUkDate RegistrationToDate { get; set; } = new();
 
     public PostcodeSearchModel PostcodeSearch { get; set; } = new();
 
 
     // Demographic information
-    [Display(Name = "Age range", Description = "Please specify the age range you wish to filter. The minimum starting age is 18.")]
+    [Display(Name = "Age range", Description = "Please specify the age range you wish to filter. The minimum starting age is 18.", Order = 8)]
     public AgeRange AgeRange { get; set; } = new();
 
 
-    [Display(Name = "Male")]
+    [Display(Name = "Male", Order = 9)]
     public bool IsSexMale { get; set; }
 
-    [Display(Name = "Female")]
+    [Display(Name = "Female", Order = 10)]
     public bool IsSexFemale { get; set; }
 
-    [Display(Name = "Yes")]
+    [Display(Name = "Yes", Order = 11)]
     public bool IsGenderSameAsSexRegisteredAtBirth_Yes { get; set; }
-    [Display(Name = "No")]
+    [Display(Name = "No", Order = 12)]
     public bool IsGenderSameAsSexRegisteredAtBirth_No { get; set; }
-    [Display(Name = "Prefer Not To Say")]
+    [Display(Name = "Prefer Not To Say", Order = 13)]
     public bool IsGenderSameAsSexRegisteredAtBirth_PreferNotToSay { get; set; }
-    [Display(Name = "Asian")]
+    [Display(Name = "Asian", Order = 14)]
     public bool Ethnicity_Asian { get; set; }
-    [Display(Name = "Black")]
+    [Display(Name = "Black", Order = 15)]
     public bool Ethnicity_Black { get; set; }
-    [Display(Name = "Mixed")]
+    [Display(Name = "Mixed", Order = 16)]
     public bool Ethnicity_Mixed { get; set; }
-    [Display(Name = "Other")]
+    [Display(Name = "Other", Order = 17)]
     public bool Ethnicity_Other { get; set; }
-    [Display(Name = "White")]
+    [Display(Name = "White", Order = 18)]
     public bool Ethnicity_White { get; set; }
     public int? VolunteerCount { get; set; }
 

--- a/BPOR/BPOR.Rms/Models/Filter/VolunteerFilterViewModel.cs
+++ b/BPOR/BPOR.Rms/Models/Filter/VolunteerFilterViewModel.cs
@@ -29,10 +29,13 @@ public class VolunteerFilterViewModel : IValidatableObject
             new SelectListItem { Value = string.Empty, Text = "No preference" },
             new SelectListItem { Value = true.ToString(), Text = "Contacted" },
             new SelectListItem { Value = false.ToString(), Text = "Not contacted" }
-        }; 
-           
+        };
+
         return items;
     }
+
+    [Display(Name = "Volunteers registered interest", Order = 2)]
+    public bool? SelectedVolunteersRegisteredInterest { get; set; }
 
     [Display(Name = "Volunteers recruited", Order = 3)]
     public bool? SelectedVolunteersRecruited { get; set; }
@@ -50,8 +53,6 @@ public class VolunteerFilterViewModel : IValidatableObject
         return items;
     }
 
-    [Display(Name = "Volunteers registered interest", Order = 2)]
-    public bool? SelectedVolunteersRegisteredInterest { get; set; }
     public IEnumerable<SelectListItem> VolunteersRegisteredInterestItems { get; set; } = SetVolunteersRegisteredInterestItems();
 
     private static IEnumerable<SelectListItem> SetVolunteersRegisteredInterestItems()
@@ -83,46 +84,47 @@ public class VolunteerFilterViewModel : IValidatableObject
     }
 
     // Areas of research volunteers are interested in
-    [Display(Name = "Areas of research volunteers are interested in")]
+    [Display(Name = "Areas of research volunteers are interested in", Order = 5)]
     public List<int> SelectedAreasOfInterest { get; set; } = [];
 
     public bool IncludeNoAreasOfInterest { get; set; }
 
-    [Display(Name = "Date of volunteer registration (from)", Order = 5)]
+    [Display(Name = "Date of volunteer registration (from)", Order = 6)]
     public GovUkDate RegistrationFromDate { get; set; } = new();
 
-    [Display(Name = "Date of volunteer registration (to)", Order = 6)]
+    [Display(Name = "Date of volunteer registration (to)", Order = 7)]
     public GovUkDate RegistrationToDate { get; set; } = new();
 
+    [Display(Order = 8)]
     public PostcodeSearchModel PostcodeSearch { get; set; } = new();
 
 
     // Demographic information
-    [Display(Name = "Age range", Description = "Please specify the age range you wish to filter. The minimum starting age is 18.", Order = 8)]
+    [Display(Name = "Age range", Description = "Please specify the age range you wish to filter. The minimum starting age is 18.", Order = 9)]
     public AgeRange AgeRange { get; set; } = new();
 
 
-    [Display(Name = "Male", Order = 9)]
+    [Display(Name = "Male", Order = 10)]
     public bool IsSexMale { get; set; }
 
-    [Display(Name = "Female", Order = 10)]
+    [Display(Name = "Female", Order = 11)]
     public bool IsSexFemale { get; set; }
 
-    [Display(Name = "Yes", Order = 11)]
+    [Display(Name = "Yes", Order = 12)]
     public bool IsGenderSameAsSexRegisteredAtBirth_Yes { get; set; }
-    [Display(Name = "No", Order = 12)]
+    [Display(Name = "No", Order = 13)]
     public bool IsGenderSameAsSexRegisteredAtBirth_No { get; set; }
-    [Display(Name = "Prefer Not To Say", Order = 13)]
+    [Display(Name = "Prefer Not To Say", Order = 14)]
     public bool IsGenderSameAsSexRegisteredAtBirth_PreferNotToSay { get; set; }
-    [Display(Name = "Asian", Order = 14)]
+    [Display(Name = "Asian", Order = 15)]
     public bool Ethnicity_Asian { get; set; }
-    [Display(Name = "Black", Order = 15)]
+    [Display(Name = "Black", Order = 16)]
     public bool Ethnicity_Black { get; set; }
-    [Display(Name = "Mixed", Order = 16)]
+    [Display(Name = "Mixed", Order = 17)]
     public bool Ethnicity_Mixed { get; set; }
-    [Display(Name = "Other", Order = 17)]
+    [Display(Name = "Other", Order = 18)]
     public bool Ethnicity_Other { get; set; }
-    [Display(Name = "White", Order = 18)]
+    [Display(Name = "White", Order = 19)]
     public bool Ethnicity_White { get; set; }
     public int? VolunteerCount { get; set; }
 
@@ -205,7 +207,7 @@ public class VolunteerFilterViewModel : IValidatableObject
             if (RegistrationFromDate.ToDateOnly() > RegistrationToDate.ToDateOnly())
             {
                 yield return new ValidationResult($"{validationContext.GetMemberDisplayName(nameof(RegistrationFromDate))} date must be on or before {validationContext.GetMemberDisplayName(nameof(RegistrationToDate))}",
-                    new[] { $"{nameof(RegistrationFromDate)}.{nameof(RegistrationFromDate.Day)}" ,$"{nameof(RegistrationToDate)}.{nameof(RegistrationToDate.Day)}"});
+                    new[] { $"{nameof(RegistrationFromDate)}.{nameof(RegistrationFromDate.Day)}", $"{nameof(RegistrationToDate)}.{nameof(RegistrationToDate.Day)}" });
             }
         }
     }
@@ -246,10 +248,10 @@ public class VolunteerFilterViewModel : IValidatableObject
 
 public class AgeRange : IValidatableObject
 {
-    [Display(Name = "From")]
+    [Display(Name = "From", Order = 1)]
     [Range(18, int.MaxValue, ErrorMessage = "Enter a whole number equal to or more than 18")]
     public int? From { get; set; }
-    [Display(Name = "To")]
+    [Display(Name = "To", Order = 2)]
     [Range(18, int.MaxValue, ErrorMessage = "Enter a whole number equal to or more than 18")]
     public int? To { get; set; }
 

--- a/BPOR/BPOR.Rms/Models/Researcher/ResearcherStudyFormViewModel.cs
+++ b/BPOR/BPOR.Rms/Models/Researcher/ResearcherStudyFormViewModel.cs
@@ -21,47 +21,49 @@ namespace BPOR.Rms.Models.Researcher
 
         public List<Submitted>? PortfolioSubmissionStatusOptions { get; set; }
 
-        [Display(Name = "Has the study been submitted for inclusion on the NIHR CRN portfolio?")]
+        [Display(Name = "Has the study been submitted for inclusion on the NIHR CRN portfolio?", Order = 4)]
         public int? PortfolioSubmissionStatus { get; set; }
 
         public List<SubmissionOutcome>? OutcomeOfSubmissionOptions { get; set; }
 
-        [Display(Name = "Outcome of submission")]
+        [Display(Name = "Outcome of submission", Order = 5)]
         public int? OutcomeOfSubmission { get; set; }        
 
-        [Display(Name = "CPMS ID")]
+        [Display(Name = "CPMS ID", Order = 6)]
         public long? CPMSId { get; set; }
 
-        [Display(Name = "Does the study have NIHR funding?")]
+        [Display(Name = "Does the study have NIHR funding?", Order = 7)]
         public bool? HasFunding { get; set; }
 
-        [Display(Name = "NIHR funding stream or grant code")]
+        [Display(Name = "NIHR funding stream or grant code", Order = 8)]
         public string? FundingCode { get; set; }
 
-        [Display(Name = "What is the UK recruitment target for the study?")]
+        [Display(Name = "What is the UK recruitment target for the study?", Order = 9)]
         public string? UKRecruitmentTarget { get; set; }
 
-        [Display(Name = "What is the target population for the study?")]
+        [Display(Name = "What is the target population for the study?", Order = 10)]
         public string? TargetPopulation { get; set; }
+        [Display(Order = 11)]
         public GovUkDate RecruitmentStartDate { get; set; } = new();
+        [Display(Order = 12)]
         public GovUkDate RecruitmentEndDate { get; set; } = new();
 
-        [Display(Name = "Will participants in the study be recruited as named individual volunteers?")]
+        [Display(Name = "Will participants in the study be recruited as named individual volunteers?", Order = 13)]
         public bool? RecruitingIdentifiableVolunteers { get; set; }
     }
 
     public class GovUkDate
     {
 
-        [Display(Name = "Day")]
+        [Display(Name = "Day", Order = 1)]
         [Range(1, 31, ErrorMessage = "Day must be between 1 and 31")]
         public int? Day { get; set; }
 
-        [Display(Name = "Month")]
+        [Display(Name = "Month", Order = 2)]
         [Range(1, 12, ErrorMessage = "Month must be between 1 and 12")]
         public int? Month { get; set; }
 
-        [Display(Name = "Year")]
+        [Display(Name = "Year", Order = 3)]
         public int? Year { get; set; }
 
 

--- a/BPOR/BPOR.Rms/Models/Researcher/ResearcherStudyFormViewModel.cs
+++ b/BPOR/BPOR.Rms/Models/Researcher/ResearcherStudyFormViewModel.cs
@@ -10,13 +10,13 @@ namespace BPOR.Rms.Models.Researcher
         [Display(Name = "Study ID")]
         public int Id { get; set; }
 
-        [Display(Name = "What is the study short name?")]
+        [Display(Name = "What is the study short name?", Order = 1)]
         public string? ShortName { get; set; }
 
-        [Display(Name = "Who is the Chief Investigator for the study?")]
+        [Display(Name = "Who is the Chief Investigator for the study?", Order = 2)]
         public string? ChiefInvestigator { get; set; }
 
-        [Display(Name = "Provide the name(s) of the study sponsor(s), funder(s) and CRO (if applicable)")]
+        [Display(Name = "Provide the name(s) of the study sponsor(s), funder(s) and CRO (if applicable)", Order = 3)]
         public string? StudySponsors { get; set; }
 
         public List<Submitted>? PortfolioSubmissionStatusOptions { get; set; }

--- a/BPOR/BPOR.Rms/Models/Study/StudyFormEditModel.cs
+++ b/BPOR/BPOR.Rms/Models/Study/StudyFormEditModel.cs
@@ -8,24 +8,24 @@ public class StudyFormEditModel : FormWithSteps
     public override int TotalSteps => 2;
 
     [Required(ErrorMessage = "Enter the name of the main contact for the study")]
-    [Display(Name = "Name of main contact for the study")]
+    [Display(Name = "Name of main contact for the study", Order = 1)]
     public string FullName { get; set; }
 
     [Required(ErrorMessage = "Enter the email address of the main contact for the study")]
     [EmailAddress(ErrorMessage = "Enter an email address in the correct format, like name@example.com")]
     [RegularExpression(@"^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$", ErrorMessage = "Enter an email address in the correct format, like name@example.com")]
-    [Display(Name = "Email address of main contact for the study")]
+    [Display(Name = "Email address of main contact for the study", Order = 2)]
     public string EmailAddress { get; set; }
 
     [Required(ErrorMessage = "Enter the study name")]
-    [Display(Name = "Study name")]
+    [Display(Name = "Study name", Order = 3)]
     public string StudyName { get; set; }
 
-    [Display(Name = "CPMS ID")]
+    [Display(Name = "CPMS ID", Order = 5)]
     [RegularExpression(@"^\d+$", ErrorMessage = "Enter a CPMS ID in the correct format, like 12345")]
     public long? CpmsId { get; set; }
     
-    [Display(Name = "Is this study recruiting identifiable participants?")]
+    [Display(Name = "Is this study recruiting identifiable participants?", Order = 4)]
     [Required(ErrorMessage = "Select whether the study is recruiting identifiable participants")]
     public bool? IsRecruitingIdentifiableParticipants { get; set; }
 }

--- a/BPOR/BPOR.Rms/Views/Shared/_Layout.cshtml
+++ b/BPOR/BPOR.Rms/Views/Shared/_Layout.cshtml
@@ -36,7 +36,7 @@
         <breadcrumbs />
         <main class="govuk-main-wrapper" id="main-content" role="main">
             <partial name="_NotificationBanner" />
-            <partial name="_ErrorSummary" />
+            <error-summary/>
             @RenderBody()
         </main>
     </div>

--- a/BPOR/BPOR.Rms/Views/_ViewImports.cshtml
+++ b/BPOR/BPOR.Rms/Views/_ViewImports.cshtml
@@ -3,5 +3,4 @@
 @using NIHR.GovUk.AspNetCore.Mvc
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, BPOR.Rms
-@addTagHelper *, BPOR.Rms.TagHelpers
 @addTagHelper *, NIHR.GovUk.AspNetCore.Mvc

--- a/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/ErrorSummaryTagHelper.cs
+++ b/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/ErrorSummaryTagHelper.cs
@@ -10,19 +10,19 @@ public class ErrorSummaryTagHelper(IHtmlHelper htmlHelper) : PartialTagHelperBas
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
     {
         output.TagName = null;
-        var model = ViewContext.ModelState
+        var modelErrors = ViewContext.ModelState
             .Where(ms => ms.Value.Errors.Count > 0)
             .DistinctBy(x => x.Value.Errors.FirstOrDefault()?.ErrorMessage);
 
         var modelProperties = ViewContext.ViewData.Model?.GetType().GetProperties();
 
         var errors = new List<KeyValuePair<int, KeyValuePair<string, ModelStateEntry>>>();
-        foreach (var keyValuePair in model)
+        foreach (var errorKeyValuePair in modelErrors)
         {
-            var modelProperty = modelProperties?.FirstOrDefault(o => o.Name == keyValuePair.Key);
+            var modelProperty = modelProperties?.FirstOrDefault(o => o.Name == errorKeyValuePair.Key);
             var displayAttribute = modelProperty?.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault() as DisplayAttribute;
             var propertyOrder = displayAttribute?.Order ?? 0;
-            errors.Add(new KeyValuePair<int, KeyValuePair<string, ModelStateEntry>>(propertyOrder, keyValuePair));
+            errors.Add(new(propertyOrder, errorKeyValuePair));
         }
 
         var orderedErrors = errors.OrderBy(o => o.Key)

--- a/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/ErrorSummaryTagHelper.cs
+++ b/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/ErrorSummaryTagHelper.cs
@@ -1,6 +1,3 @@
-using System.ComponentModel.DataAnnotations;
-using System.Reflection;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Logging;
@@ -12,103 +9,15 @@ public class ErrorSummaryTagHelper(IHtmlHelper htmlHelper, ILogger<ErrorSummaryT
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
     {
         output.TagName = null;
+
         if (ViewContext.ViewData.ModelState.IsValid)
         {
             output.SuppressOutput();
-            return;
         }
-
-        var modelErrors = ViewContext.ModelState
-            .Where(ms => ms.Value.Errors.Count > 0)
-            .DistinctBy(x => x.Value.Errors.FirstOrDefault()?.ErrorMessage);
-
-        var modelProperties = ViewContext.ViewData.Model?.GetType().GetProperties();
-
-        var errors = new List<KeyValuePair<List<int>, KeyValuePair<string, ModelStateEntry>>>();
-        foreach (var errorKeyValuePair in modelErrors)
+        else
         {
-            var modelProperty = modelProperties?.FirstOrDefault(o => o.Name == errorKeyValuePair.Key);
-            if (modelProperty is not null)
-            {
-                var displayAttribute =
-                    modelProperty?.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault() as
-                        DisplayAttribute;
-                var propertyOrder = displayAttribute?.GetOrder() ?? int.MaxValue;
-                errors.Add(new([propertyOrder], errorKeyValuePair));
-            }
-            else
-            {
-                var pathToErrorModelProperties = errorKeyValuePair.Key.Split('.');
-                var nestedModelObject = pathToErrorModelProperties.Length > 1;
-                if (!nestedModelObject)
-                {
-                    logger.LogWarning(
-                        "Unable to identify a matching model ({model}) property from model state for error key {key}",
-                        nameof(ViewContext.ViewData.Model), errorKeyValuePair.Key);
-                    errors.Add(new([int.MaxValue], errorKeyValuePair));
-                }
-
-                errors.Add(GetNestedPropertyOrder(errorKeyValuePair, pathToErrorModelProperties, modelProperties));
-            }
-        }
-
-        var orderedErrors = errors
-            .OrderBy(o => o.Key, new ListOfIntComparer())
-            .Select(o => o.Value);
-        
-        var content = await RenderPartialAsync("_ErrorSummary", orderedErrors);
-        output.Content.SetHtmlContent(content);
-    }
-
-    private KeyValuePair<List<int>, KeyValuePair<string, ModelStateEntry>> GetNestedPropertyOrder(KeyValuePair<string, ModelStateEntry> errorKeyValuePair, string[] pathToErrorModelProperties, PropertyInfo[] parentModelProperties)
-    {
-        var nestedPropertyOrder = new List<int>();
-        //First get the parent property 
-        var parentPropertyName = pathToErrorModelProperties[0];
-        var parentProperty = parentModelProperties?.FirstOrDefault(o => o.Name == parentPropertyName);
-        nestedPropertyOrder.Add(GetOrderFromDisplayAttribute(parentProperty, parentPropertyName));
-        var nestedType = parentProperty.PropertyType;
-        //Then iterate through the model
-        for (var i = 1; i < pathToErrorModelProperties.Length; i++)
-        {
-            var nestedProperties = nestedType.GetProperties();
-            var nestedProperty = nestedProperties.FirstOrDefault(o => o.Name == pathToErrorModelProperties[i]);
-            nestedPropertyOrder.Add(GetOrderFromDisplayAttribute(nestedProperty, pathToErrorModelProperties[i]));
-            nestedType = nestedProperty.PropertyType;
-        }
-
-        return new(nestedPropertyOrder, errorKeyValuePair);
-    }
-
-    private int GetOrderFromDisplayAttribute(PropertyInfo property, string propertyName)
-    {
-        var displayAttribute = property?.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault() as DisplayAttribute;
-        return displayAttribute?.GetOrder() ?? int.MaxValue;
-    }
-
-    private class ListOfIntComparer : IComparer<List<int>>
-    {
-        public int Compare(List<int> x, List<int> y)
-        {
-            if (x == null || y == null)
-            {
-                return (x == null) ? ((y == null) ? 0 : -1) : 1;
-            }
-
-            int minLength = Math.Min(x.Count, y.Count);
-            for (int i = 0; i < minLength; i++)
-            {
-                int result = x[i].CompareTo(y[i]);
-                if (result != 0)
-                {
-                    return result;
-                }
-            }
-
-            // If all compared elements are equal, the shorter list is considered less
-            return x.Count.CompareTo(y.Count);
+            var content = await RenderPartialAsync("_ErrorSummary", ViewContext.Errors());
+            output.Content.SetHtmlContent(content);
         }
     }
 }
-
-

--- a/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/ErrorSummaryTagHelper.cs
+++ b/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/ErrorSummaryTagHelper.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace NIHR.GovUk.AspNetCore.Mvc.TagHelpers;
+
+public class ErrorSummaryTagHelper(IHtmlHelper htmlHelper) : PartialTagHelperBase(htmlHelper)
+{
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagName = null;
+        var model = ViewContext.ModelState
+            .Where(ms => ms.Value.Errors.Count > 0)
+            .DistinctBy(x => x.Value.Errors.FirstOrDefault()?.ErrorMessage);
+
+        var modelProperties = ViewContext.ViewData.Model?.GetType().GetProperties();
+
+        var errors = new List<KeyValuePair<int, KeyValuePair<string, ModelStateEntry>>>();
+        foreach (var keyValuePair in model)
+        {
+            var modelProperty = modelProperties?.FirstOrDefault(o => o.Name == keyValuePair.Key);
+            var displayAttribute = modelProperty?.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault() as DisplayAttribute;
+            var propertyOrder = displayAttribute?.Order ?? 0;
+            errors.Add(new KeyValuePair<int, KeyValuePair<string, ModelStateEntry>>(propertyOrder, keyValuePair));
+        }
+
+        var orderedErrors = errors.OrderBy(o => o.Key)
+            .Select(x => x.Value);
+        
+        var content = await RenderPartialAsync("_ErrorSummary", orderedErrors);
+        output.Content.SetHtmlContent(content);
+    }
+}

--- a/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/ErrorSummaryTagHelper.cs
+++ b/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/ErrorSummaryTagHelper.cs
@@ -1,34 +1,115 @@
 using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Logging;
 
 namespace NIHR.GovUk.AspNetCore.Mvc.TagHelpers;
 
-public class ErrorSummaryTagHelper(IHtmlHelper htmlHelper) : PartialTagHelperBase(htmlHelper)
+public class ErrorSummaryTagHelper(IHtmlHelper htmlHelper, ILogger<ErrorSummaryTagHelper> logger) : PartialTagHelperBase(htmlHelper)
 {
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
     {
         output.TagName = null;
+        if (ViewContext.ViewData.ModelState.IsValid)
+        {
+            output.SuppressOutput();
+            return;
+        }
+
         var modelErrors = ViewContext.ModelState
             .Where(ms => ms.Value.Errors.Count > 0)
             .DistinctBy(x => x.Value.Errors.FirstOrDefault()?.ErrorMessage);
 
         var modelProperties = ViewContext.ViewData.Model?.GetType().GetProperties();
 
-        var errors = new List<KeyValuePair<int, KeyValuePair<string, ModelStateEntry>>>();
+        var errors = new List<KeyValuePair<List<int>, KeyValuePair<string, ModelStateEntry>>>();
         foreach (var errorKeyValuePair in modelErrors)
         {
             var modelProperty = modelProperties?.FirstOrDefault(o => o.Name == errorKeyValuePair.Key);
-            var displayAttribute = modelProperty?.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault() as DisplayAttribute;
-            var propertyOrder = displayAttribute?.Order ?? 0;
-            errors.Add(new(propertyOrder, errorKeyValuePair));
+            if (modelProperty is not null)
+            {
+                var displayAttribute =
+                    modelProperty?.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault() as
+                        DisplayAttribute;
+                var propertyOrder = displayAttribute?.GetOrder() ?? int.MaxValue;
+                errors.Add(new([propertyOrder], errorKeyValuePair));
+            }
+            else
+            {
+                var pathToErrorModelProperties = errorKeyValuePair.Key.Split('.');
+                var nestedModelObject = pathToErrorModelProperties.Length > 1;
+                if (!nestedModelObject)
+                {
+                    logger.LogWarning(
+                        "Unable to identify a matching model ({model}) property from model state for error key {key}",
+                        nameof(ViewContext.ViewData.Model), errorKeyValuePair.Key);
+                    errors.Add(new([int.MaxValue], errorKeyValuePair));
+                }
+
+                errors.Add(GetNestedPropertyOrder(errorKeyValuePair, pathToErrorModelProperties, modelProperties));
+            }
         }
 
-        var orderedErrors = errors.OrderBy(o => o.Key)
-            .Select(x => x.Value);
+        var orderedErrors = errors
+            .OrderBy(o => o.Key, new ListOfIntComparer())
+            .Select(o => o.Value);
         
         var content = await RenderPartialAsync("_ErrorSummary", orderedErrors);
         output.Content.SetHtmlContent(content);
     }
+
+    private KeyValuePair<List<int>, KeyValuePair<string, ModelStateEntry>> GetNestedPropertyOrder(KeyValuePair<string, ModelStateEntry> errorKeyValuePair, string[] pathToErrorModelProperties, PropertyInfo[] parentModelProperties)
+    {
+        var nestedPropertyOrder = new List<int>();
+        //First get the parent property 
+        var parentPropertyName = pathToErrorModelProperties[0];
+        var parentProperty = parentModelProperties?.FirstOrDefault(o => o.Name == parentPropertyName);
+        nestedPropertyOrder.Add(GetOrderFromDisplayAttribute(parentProperty, parentPropertyName));
+        var nestedType = parentProperty.PropertyType;
+        //Then iterate through the model
+        for (var i = 1; i < pathToErrorModelProperties.Length; i++)
+        {
+            var nestedProperties = nestedType.GetProperties();
+            var nestedProperty = nestedProperties.FirstOrDefault(o => o.Name == pathToErrorModelProperties[i]);
+            nestedPropertyOrder.Add(GetOrderFromDisplayAttribute(nestedProperty, pathToErrorModelProperties[i]));
+            nestedType = nestedProperty.PropertyType;
+        }
+
+        return new(nestedPropertyOrder, errorKeyValuePair);
+    }
+
+    private int GetOrderFromDisplayAttribute(PropertyInfo property, string propertyName)
+    {
+        var displayAttribute = property?.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault() as DisplayAttribute;
+        return displayAttribute?.GetOrder() ?? int.MaxValue;
+    }
+
+    private class ListOfIntComparer : IComparer<List<int>>
+    {
+        public int Compare(List<int> x, List<int> y)
+        {
+            if (x == null || y == null)
+            {
+                return (x == null) ? ((y == null) ? 0 : -1) : 1;
+            }
+
+            int minLength = Math.Min(x.Count, y.Count);
+            for (int i = 0; i < minLength; i++)
+            {
+                int result = x[i].CompareTo(y[i]);
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+
+            // If all compared elements are equal, the shorter list is considered less
+            return x.Count.CompareTo(y.Count);
+        }
+    }
 }
+
+

--- a/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/ErrorSummaryTagHelper.cs
+++ b/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/ErrorSummaryTagHelper.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;

--- a/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/FormGroupTagHelper.cs
+++ b/BPOR/NIHR.GovUk.AspNetCore.Mvc/TagHelpers/FormGroupTagHelper.cs
@@ -56,8 +56,6 @@ namespace NIHR.GovUk.AspNetCore.Mvc.TagHelpers
                 modelNames.AddRange(ViewContext.ViewData.ModelState.Where(x => x.Key.StartsWith(childPrefix)).Select(x => x.Key));
             }
 
-
-
             var modelState = ViewContext.ViewData.ModelState.Where(x => modelNames.Contains(x.Key));
 
             if (modelState?.Where(x => x.Value?.Errors.Count > 0).Any() ?? false)
@@ -82,11 +80,11 @@ namespace NIHR.GovUk.AspNetCore.Mvc.TagHelpers
                 output.PreContent.AppendHtml(hintBuilder);
             }
 
-            foreach (var name in modelNames)
+            if (!ViewContext.ViewData.ModelState.IsValid)
             {
-                if (ViewContext.ViewData.ModelState[name]?.Errors.Count > 0)
+                foreach (var error in ViewContext.Errors().Where(x => modelNames.Contains(x.Key)))
                 {
-                    var validationMessage = _generator.GenerateValidationMessage(ViewContext, For.ModelExplorer, name, null, null, null);
+                    var validationMessage = _generator.GenerateValidationMessage(ViewContext, For.ModelExplorer, error.Key, null, null, null);
 
                     output.PreContent.AppendHtml($"""
                     <span class="govuk-error-message">

--- a/BPOR/NIHR.GovUk.AspNetCore.Mvc/ViewContextExtensions.cs
+++ b/BPOR/NIHR.GovUk.AspNetCore.Mvc/ViewContextExtensions.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace NIHR.GovUk
+{
+    public static class ViewContextExtensions
+    {
+        public static IEnumerable<KeyValuePair<string, ModelStateEntry>> Errors(this ViewContext viewContext)
+        {
+            var modelErrors = viewContext.ViewData.ModelState
+                .Where(ms => ms.Value.Errors.Count > 0)
+                .DistinctBy(x => x.Value.Errors.FirstOrDefault()?.ErrorMessage);
+
+            var s = viewContext.ViewData.ModelExplorer;
+            var modelProperties = viewContext.ViewData.Model?.GetType().GetProperties();
+
+            var errors = new List<KeyValuePair<List<int>, KeyValuePair<string, ModelStateEntry>>>();
+            foreach (var errorKeyValuePair in modelErrors)
+            {
+                var modelProperty = modelProperties?.FirstOrDefault(o => o.Name == errorKeyValuePair.Key);
+                if (modelProperty is not null)
+                {
+                    var displayAttribute =
+                        modelProperty?.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault() as
+                            DisplayAttribute;
+                    var propertyOrder = displayAttribute?.GetOrder() ?? int.MaxValue;
+                    errors.Add(new([propertyOrder], errorKeyValuePair));
+                }
+                else
+                {
+                    var pathToErrorModelProperties = errorKeyValuePair.Key.Split('.');
+                    var nestedModelObject = pathToErrorModelProperties.Length > 1;
+                    if (!nestedModelObject)
+                    {
+                        errors.Add(new([int.MaxValue], errorKeyValuePair));
+                    }
+
+                    errors.Add(GetNestedPropertyOrder(errorKeyValuePair, pathToErrorModelProperties, modelProperties));
+                }
+            }
+
+            return errors
+                .OrderBy(o => o.Key, new ListOfIntComparer())
+                .Select(o => o.Value)
+                .ToList();
+        }
+
+        private static KeyValuePair<List<int>, KeyValuePair<string, ModelStateEntry>> GetNestedPropertyOrder(KeyValuePair<string, ModelStateEntry> errorKeyValuePair, string[] pathToErrorModelProperties, PropertyInfo[] parentModelProperties)
+        {
+            var nestedPropertyOrder = new List<int>();
+            //First get the parent property 
+            var parentPropertyName = pathToErrorModelProperties[0];
+            var parentProperty = parentModelProperties?.FirstOrDefault(o => o.Name == parentPropertyName);
+            if (parentProperty is not null) // TODO: investigate missing postcode model error message in form-group.
+            {
+                nestedPropertyOrder.Add(GetOrderFromDisplayAttribute(parentProperty));
+                var nestedType = parentProperty.PropertyType;
+                //Then iterate through the model
+                for (var i = 1; i < pathToErrorModelProperties.Length; i++)
+                {
+                    var nestedProperties = nestedType.GetProperties();
+                    var nestedProperty = nestedProperties.FirstOrDefault(o => o.Name == pathToErrorModelProperties[i]);
+                    nestedPropertyOrder.Add(GetOrderFromDisplayAttribute(nestedProperty));
+                    nestedType = nestedProperty.PropertyType;
+                }
+            }
+
+            return new(nestedPropertyOrder, errorKeyValuePair);
+        }
+
+        private static int GetOrderFromDisplayAttribute(PropertyInfo property)
+        {
+            var displayAttribute = property?.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault() as DisplayAttribute;
+            return displayAttribute?.GetOrder() ?? int.MaxValue;
+        }
+
+        private class ListOfIntComparer : IComparer<List<int>>
+        {
+            public int Compare(List<int> x, List<int> y)
+            {
+                if (x == null || y == null)
+                {
+                    return (x == null) ? ((y == null) ? 0 : -1) : 1;
+                }
+
+                int minLength = Math.Min(x.Count, y.Count);
+                for (int i = 0; i < minLength; i++)
+                {
+                    int result = x[i].CompareTo(y[i]);
+                    if (result != 0)
+                    {
+                        return result;
+                    }
+                }
+
+                // If all compared elements are equal, the shorter list is considered less
+                return x.Count.CompareTo(y.Count);
+            }
+        }
+    }
+}

--- a/BPOR/NIHR.GovUk.AspNetCore.Mvc/Views/Shared/_ErrorSummary.cshtml
+++ b/BPOR/NIHR.GovUk.AspNetCore.Mvc/Views/Shared/_ErrorSummary.cshtml
@@ -1,22 +1,20 @@
 @using Microsoft.AspNetCore.Mvc.ModelBinding
 @model IEnumerable<KeyValuePair<string, ModelStateEntry?>>?
 
-@if (!ViewData.ModelState.IsValid)
-{
-    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
-         data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-        </h2>
-        <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-                @foreach (var error in Model)
-                {
-                    <li>
-                        <a href="#@error.Key.Replace(".", "_")">@error.Value.Errors[0].ErrorMessage</a>
-                    </li>
-                }
-            </ul>
-        </div>
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+     data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+            @foreach (var error in Model)
+            {
+                <li>
+                    <a href="#@error.Key.Replace(".", "_")">@error.Value.Errors[0].ErrorMessage</a>
+                </li>
+            }
+        </ul>
     </div>
-}
+</div>
+

--- a/BPOR/NIHR.GovUk.AspNetCore.Mvc/Views/Shared/_ErrorSummary.cshtml
+++ b/BPOR/NIHR.GovUk.AspNetCore.Mvc/Views/Shared/_ErrorSummary.cshtml
@@ -1,15 +1,5 @@
-<style>
-    .govuk-error-summary:focus {
-        outline: 3px solid #FED47A
-    }
-
-    .govuk-error-summary__list a:focus {
-        text-decoration: none;
-        background-color: rgb(254, 212, 122);
-        box-shadow: rgb(254, 212, 122) 0px -2px, rgb(33, 43, 50) 0px 4px;
-        color: #193E72;
-    }
-</style>
+@using Microsoft.AspNetCore.Mvc.ModelBinding
+@model IEnumerable<KeyValuePair<string, ModelStateEntry?>>?
 
 @if (!ViewData.ModelState.IsValid)
 {
@@ -20,7 +10,7 @@
         </h2>
         <div class="govuk-error-summary__body">
             <ul class="govuk-list govuk-error-summary__list">
-                @foreach (var error in ViewData.ModelState.Where(ms => ms.Value.Errors.Count > 0).DistinctBy(x => x.Value.Errors.FirstOrDefault()?.ErrorMessage))
+                @foreach (var error in Model)
                 {
                     <li>
                         <a href="#@error.Key.Replace(".", "_")">@error.Value.Errors[0].ErrorMessage</a>


### PR DESCRIPTION
[CRNCC-2251](https://nihr.atlassian.net/browse/CRNCC-2251) Errors listed in error summary not in same order as fields on page

- Added display order to all models to be used in the view
- Added a tag helper to handle the display of errors which reads the order of the model display attributes
- Modified the error summary to include the new tag helper