### PR TITLE
Ticket/main/crncc 3199

### DIFF
--- a/Dynamo.Stream.Handler/src/Dynamo.Stream.Handler/Entities/Participant.cs
+++ b/Dynamo.Stream.Handler/src/Dynamo.Stream.Handler/Entities/Participant.cs
@@ -75,5 +75,6 @@ public class Participant : ISoftDelete, ITimestamped, IPersonalInformation
         HasLongTermCondition = null; // TODO: confirm we are clearing this but not DailyLifeImpact?
         Address?.Anonymise();
         HealthConditions.Clear();
+        NHSNumber = null;
     }
 }

--- a/Dynamo.Stream.Handler/src/Dynamo.Stream.Handler/Entities/Participant.cs
+++ b/Dynamo.Stream.Handler/src/Dynamo.Stream.Handler/Entities/Participant.cs
@@ -72,9 +72,9 @@ public class Participant : ISoftDelete, ITimestamped, IPersonalInformation
         LandlineNumber = null;
         RegistrationConsent = false;
         RemovalOfConsentRegistrationAtUtc = DateTime.UtcNow;
+        NHSNumber = null;
         HasLongTermCondition = null; // TODO: confirm we are clearing this but not DailyLifeImpact?
         Address?.Anonymise();
         HealthConditions?.Clear();
-        NHSNumber = null;
     }
 }

--- a/Dynamo.Stream.Handler/src/Dynamo.Stream.Handler/Entities/Participant.cs
+++ b/Dynamo.Stream.Handler/src/Dynamo.Stream.Handler/Entities/Participant.cs
@@ -72,9 +72,8 @@ public class Participant : ISoftDelete, ITimestamped, IPersonalInformation
         LandlineNumber = null;
         RegistrationConsent = false;
         RemovalOfConsentRegistrationAtUtc = DateTime.UtcNow;
-        NHSNumber = null;
         HasLongTermCondition = null; // TODO: confirm we are clearing this but not DailyLifeImpact?
         Address?.Anonymise();
-        HealthConditions?.Clear();
+        HealthConditions.Clear();
     }
 }

--- a/Dynamo.Stream.Handler/src/Dynamo.Stream.Handler/Entities/Participant.cs
+++ b/Dynamo.Stream.Handler/src/Dynamo.Stream.Handler/Entities/Participant.cs
@@ -74,7 +74,7 @@ public class Participant : ISoftDelete, ITimestamped, IPersonalInformation
         RemovalOfConsentRegistrationAtUtc = DateTime.UtcNow;
         HasLongTermCondition = null; // TODO: confirm we are clearing this but not DailyLifeImpact?
         Address?.Anonymise();
-        HealthConditions.Clear();
+        HealthConditions?.Clear();
         NHSNumber = null;
     }
 }

--- a/src/Application/Contracts/IParticipantRepository.cs
+++ b/src/Application/Contracts/IParticipantRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2.Model;
 using Domain.Entities.Participants;
@@ -16,5 +17,6 @@ namespace Application.Contracts
         Task DeleteParticipantDetailsAsync(ParticipantDetails entity);
         Task CreateAnonymisedDemographicParticipantDataAsync(ParticipantDetails entity);
         Task<ParticipantDetails> QueryIndexForParticipantDetailsAsync(string query, string colName);
+        Task<IReadOnlyCollection<ParticipantDetails>> GetAllParticipantDetailsByEmailAsync(string email);
     }
 }

--- a/src/Application/Contracts/IParticipantRepository.cs
+++ b/src/Application/Contracts/IParticipantRepository.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Amazon.DynamoDBv2.Model;
 using Domain.Entities.Participants;
 
 namespace Application.Contracts
@@ -12,7 +11,6 @@ namespace Application.Contracts
         Task CreateParticipantDetailsAsync(ParticipantDetails entity);
         Task UpdateParticipantDetailsAsync(ParticipantDetails entity);
         Task CreateParticipantDemographicsAsync(ParticipantDemographics entity);
-        Task AddDemographicsToNhsUserAsync(ParticipantDemographics entity, string nhsId);
         Task UpdateParticipantDemographicsAsync(ParticipantDemographics entity);
         Task DeleteParticipantDetailsAsync(ParticipantDetails entity);
         Task CreateAnonymisedDemographicParticipantDataAsync(ParticipantDetails entity);

--- a/src/Application/Mappings/Participants/ParticipantMapper.cs
+++ b/src/Application/Mappings/Participants/ParticipantMapper.cs
@@ -1,5 +1,4 @@
 using Application.Models.Participants;
-using Application.Participants.V1.Commands.Participants;
 using Application.Responses.V1.Participants;
 using Domain.Entities.Participants;
 
@@ -51,7 +50,7 @@ namespace Application.Mappings.Participants
                 Disability = source.Disability,
                 DisabilityDescription = source.DisabilityDescription,
                 HealthConditionInterests = source.HealthConditionInterests,
-                HasDemographics = source.HasDemographics,
+                HasDemographics = source.HasDemographics(),
                 SelectedLocale = source.SelectedLocale ?? "en-GB"
             };
         }

--- a/src/Application/Participants/V1/Commands/Participants/CreateParticipantDemographicsCommand.cs
+++ b/src/Application/Participants/V1/Commands/Participants/CreateParticipantDemographicsCommand.cs
@@ -94,7 +94,7 @@ namespace Application.Participants.V1.Commands.Participants
 
                     _logger.LogInformation("Participant: {@entity}", entity);
 
-                    if (!entity.HasDemographics)
+                    if (!entity.HasDemographics())
                     {
                         var user = await _participantRepository.GetParticipantDetailsAsync(request.ParticipantId);
 

--- a/src/Application/Participants/V1/Queries/Participants/GetParticipantDemographicsQuery.cs
+++ b/src/Application/Participants/V1/Queries/Participants/GetParticipantDemographicsQuery.cs
@@ -54,7 +54,7 @@ namespace Application.Participants.V1.Queries.Participants
                     }
                     
 
-                    if (!participantDemographics.HasDemographics)
+                    if (!participantDemographics.HasDemographics())
                     {
                         return Response<ParticipantDemographicsResponse>.CreateNotFoundResponse(
                             ProjectAssemblyNames.ApiAssemblyName, nameof(GetParticipantDemographicsQueryHandler), "err",

--- a/src/Domain/Entities/Participants/Participant.cs
+++ b/src/Domain/Entities/Participants/Participant.cs
@@ -38,24 +38,26 @@ public class Participant
     [DynamoDBProperty] public string SelectedLocale { get; set; }
     [DynamoDBProperty] public List<string> HealthConditionInterests { get; set; }
 
-    public bool HasDemographics => SexRegisteredAtBirth != null;
+    public bool HasDemographics() => SexRegisteredAtBirth != null;
 
     public void ApplyDemographics(ParticipantDemographics demographics)
     {
-        if (demographics == null)
+        if (demographics == null || !demographics.HasDemographics())
         {
             return;
         }
 
-        MobileNumber = demographics.MobileNumber;
-        LandlineNumber = demographics.LandlineNumber;
+        EthnicGroup = demographics.EthnicGroup;
         Address = demographics.Address;
+        Disability = demographics.Disability;
+        EthnicBackground = demographics.EthnicBackground;
         SexRegisteredAtBirth = demographics.SexRegisteredAtBirth;
         GenderIsSameAsSexRegisteredAtBirth = demographics.GenderIsSameAsSexRegisteredAtBirth;
-        EthnicGroup = demographics.EthnicGroup;
-        EthnicBackground = demographics.EthnicBackground;
-        Disability = demographics.Disability;
-        DisabilityDescription = demographics.DisabilityDescription;
+        MobileNumber = demographics.MobileNumber;
         HealthConditionInterests = demographics.HealthConditionInterests;
+        DisabilityDescription = demographics.DisabilityDescription;
+        LandlineNumber = demographics.LandlineNumber;
+        SelectedLocale = demographics.SelectedLocale;
+        Stage2CompleteUtc = demographics.Stage2CompleteUtc;
     }
 }

--- a/src/Domain/Entities/Participants/Participant.cs
+++ b/src/Domain/Entities/Participants/Participant.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using Amazon.DynamoDBv2.DataModel;
 using Domain.Converters;
 
 namespace Domain.Entities.Participants;
@@ -39,4 +36,23 @@ public class Participant
     [DynamoDBProperty] public List<string> HealthConditionInterests { get; set; }
 
     public bool HasDemographics => SexRegisteredAtBirth != null;
+
+    public void ApplyDemographics(ParticipantDemographics demographics)
+    {
+        if (demographics == null)
+        {
+            return;
+        }
+
+        MobileNumber = demographics.MobileNumber;
+        LandlineNumber = demographics.LandlineNumber;
+        Address = demographics.Address;
+        SexRegisteredAtBirth = demographics.SexRegisteredAtBirth;
+        GenderIsSameAsSexRegisteredAtBirth = demographics.GenderIsSameAsSexRegisteredAtBirth;
+        EthnicGroup = demographics.EthnicGroup;
+        EthnicBackground = demographics.EthnicBackground;
+        Disability = demographics.Disability;
+        DisabilityDescription = demographics.DisabilityDescription;
+        HealthConditionInterests = demographics.HealthConditionInterests;
+    }
 }

--- a/src/Domain/Entities/Participants/Participant.cs
+++ b/src/Domain/Entities/Participants/Participant.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using Amazon.DynamoDBv2.DataModel;
 using Domain.Converters;
 
 namespace Domain.Entities.Participants;

--- a/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
+++ b/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
+++ b/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
@@ -86,9 +86,9 @@ namespace Infrastructure.Persistence
         public async Task CreateParticipantDetailsAsync(ParticipantDetails entity)
         {
             // TODO pull out this logic into a mapper
-            entity.Pk = ParticipantKey(string.IsNullOrEmpty(entity.ParticipantId)
-                ? entity.NhsId
-                : entity.ParticipantId);
+            entity.Pk = ParticipantKey(string.IsNullOrEmpty(entity.NhsId)
+                ? entity.ParticipantId
+                : entity.NhsId);
             entity.Sk = ParticipantKey();
 
             await _context.SaveAsync(entity, _config);

--- a/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
+++ b/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
@@ -86,9 +86,9 @@ namespace Infrastructure.Persistence
         public async Task CreateParticipantDetailsAsync(ParticipantDetails entity)
         {
             // TODO pull out this logic into a mapper
-            entity.Pk = ParticipantKey(string.IsNullOrEmpty(entity.NhsId)
-                ? entity.ParticipantId
-                : entity.NhsId);
+            entity.Pk = ParticipantKey(string.IsNullOrEmpty(entity.ParticipantId)
+                ? entity.NhsId
+                : entity.ParticipantId);
             entity.Sk = ParticipantKey();
 
             await _context.SaveAsync(entity, _config);

--- a/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
+++ b/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DataModel;

--- a/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
+++ b/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
@@ -104,15 +104,10 @@ namespace Infrastructure.Persistence
 
                 foreach (var item in response.Items)
                 {
-                    var indexParticipant = _context.FromDocument<ParticipantDetails>(Document.FromAttributeMap(item));
-
-                    var participantId = indexParticipant.Pk.Replace("PARTICIPANT#", "");
-
-                    var fullParticipant = await GetParticipantDetailsAsync(participantId);
-
-                    if (fullParticipant != null)
+                    var participant = _context.FromDocument<ParticipantDetails>(Document.FromAttributeMap(item));
+                    if (participant != null)
                     {
-                        results.Add(fullParticipant);
+                        results.Add(participant);
                     }
                 }
 

--- a/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
+++ b/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DataModel;
@@ -75,6 +74,55 @@ namespace Infrastructure.Persistence
                 Console.WriteLine(e);
                 throw;
             }
+        }
+
+        public async Task<IReadOnlyCollection<ParticipantDetails>> GetAllParticipantDetailsByEmailAsync(string email)
+        {
+            var results = new List<ParticipantDetails>();
+            Dictionary<string, AttributeValue> lastEvaluatedKey = null;
+
+            do
+            {
+                var request = new QueryRequest
+                {
+                    TableName = _config.OverrideTableName,
+                    IndexName = "EmailIndex",
+                    KeyConditionExpression = "Email = :email",
+                    ExpressionAttributeValues =
+                        new Dictionary<string, AttributeValue>
+                        {
+                            [":email"] = new AttributeValue
+                            {
+                                S = email.ToLowerInvariant()
+                            }
+                        },
+                    ExclusiveStartKey = lastEvaluatedKey
+                };
+
+                var response = await _client.QueryAsync(request);
+
+                foreach (var item in response.Items)
+                {
+                    var indexParticipant = _context.FromDocument<ParticipantDetails>(Document.FromAttributeMap(item));
+
+                    var participantId = indexParticipant.Pk.Replace("PARTICIPANT#", "");
+
+                    var fullParticipant = await GetParticipantDetailsAsync(participantId);
+
+                    if (fullParticipant != null)
+                    {
+                        results.Add(fullParticipant);
+                    }
+                }
+
+                lastEvaluatedKey = response.LastEvaluatedKey?.Count > 0 ? response.LastEvaluatedKey : null;
+            }
+            while (lastEvaluatedKey != null);
+
+            return results
+                .GroupBy(x => x.Pk)
+                .Select(x => x.First())
+                .ToList();
         }
 
         public async Task<ParticipantDemographics> GetParticipantDemographicsAsync(string participantId)

--- a/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
+++ b/src/Infrastructure/Persistence/ParticipantDynamoDbRepository.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
@@ -10,7 +6,9 @@ using Application.Contracts;
 using Application.Settings;
 using Domain.Entities.Participants;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Infrastructure.Persistence
 {
@@ -40,44 +38,7 @@ namespace Infrastructure.Persistence
                 _config);
         }
 
-        public async Task<ParticipantDetails> QueryIndexForParticipantDetailsAsync(string query, string colName)
-        {
-            var request = new QueryRequest
-            {
-                TableName = _config.OverrideTableName,
-                KeyConditionExpression = $"{colName} = :value",
-                ExpressionAttributeValues = new Dictionary<string, AttributeValue>
-                {
-                    { ":value", new AttributeValue { S = query } }
-                },
-                IndexName = $"{colName}Index",
-            };
-
-            _logger.LogInformation("request: {@Request}", request);
-
-            try
-            {
-                var response = await _client.QueryAsync(request);
-
-                _logger.LogInformation("response: {@Response}", response);
-
-                var items = response.Items;
-                if (items.Count == 0) return null;
-                var item = items.OrderByDescending(x => DateTime.Parse(x["CreatedAtUtc"].S)).First();
-
-                _logger.LogInformation("item: {@Item}", item);
-
-                var participant = _context.FromDocument<ParticipantDetails>(Document.FromAttributeMap(item));
-                return await GetParticipantDetailsAsync(participant.Pk.Replace("PARTICIPANT#", ""));
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                throw;
-            }
-        }
-
-        public async Task<IReadOnlyCollection<ParticipantDetails>> GetAllParticipantDetailsByEmailAsync(string email)
+        private async Task<IEnumerable<ParticipantDetails>> QueryIndexAsync(string query, string colName)
         {
             var results = new List<ParticipantDetails>();
             Dictionary<string, AttributeValue> lastEvaluatedKey = null;
@@ -87,16 +48,13 @@ namespace Infrastructure.Persistence
                 var request = new QueryRequest
                 {
                     TableName = _config.OverrideTableName,
-                    IndexName = "EmailIndex",
-                    KeyConditionExpression = "Email = :email",
+                    KeyConditionExpression = $"{colName} = :value",
                     ExpressionAttributeValues =
                         new Dictionary<string, AttributeValue>
                         {
-                            [":email"] = new AttributeValue
-                            {
-                                S = email.ToLowerInvariant()
-                            }
+                            { ":value", new AttributeValue { S = query } }
                         },
+                    IndexName = $"{colName}Index",
                     ExclusiveStartKey = lastEvaluatedKey
                 };
 
@@ -115,10 +73,25 @@ namespace Infrastructure.Persistence
             }
             while (lastEvaluatedKey != null);
 
-            return results
-                .GroupBy(x => x.Pk)
-                .Select(x => x.First())
-                .ToList();
+            return results;
+        }
+
+
+        public async Task<ParticipantDetails> QueryIndexForParticipantDetailsAsync(string query, string colName)
+        {
+            var items = await QueryIndexAsync(query, colName);
+
+            if (!items.Any())
+            {
+                return null;
+            }
+
+            return items.OrderByDescending(x => x.CreatedAtUtc).First();
+        }
+
+        public async Task<IReadOnlyCollection<ParticipantDetails>> GetAllParticipantDetailsByEmailAsync(string email)
+        {
+            return (await QueryIndexAsync(email, "Email")).ToList().AsReadOnly();
         }
 
         public async Task<ParticipantDemographics> GetParticipantDemographicsAsync(string participantId)
@@ -146,14 +119,6 @@ namespace Infrastructure.Persistence
         public async Task CreateParticipantDemographicsAsync(ParticipantDemographics entity)
         {
             entity.Pk = ParticipantKey(entity.ParticipantId);
-            entity.Sk = ParticipantKey();
-
-            await _context.SaveAsync(entity, _config);
-        }
-
-        public async Task AddDemographicsToNhsUserAsync(ParticipantDemographics entity, string nhsId)
-        {
-            entity.Pk = ParticipantKey(nhsId);
             entity.Sk = ParticipantKey();
 
             await _context.SaveAsync(entity, _config);

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -89,7 +88,7 @@ public class ParticipantService : IParticipantService
             NhsId = request.NhsId,
             NhsNumber = request.NhsNumber,
             Email = request.Email,
-            ParticipantId = request.NhsId,
+            ParticipantId = participant.ParticipantId,
             Firstname = request.Firstname,
             Lastname = request.Lastname,
             ConsentRegistration = participant.ConsentRegistration,

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -87,7 +87,7 @@ public class ParticipantService : IParticipantService
             NhsId = request.NhsId,
             NhsNumber = request.NhsNumber,
             Email = request.Email,
-            ParticipantId = participant.ParticipantId,
+            ParticipantId = request.NhsId,
             Firstname = request.Firstname,
             Lastname = request.Lastname,
             ConsentRegistration = participant.ConsentRegistration,

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -88,7 +88,7 @@ public class ParticipantService : IParticipantService
             NhsId = request.NhsId,
             NhsNumber = request.NhsNumber,
             Email = request.Email,
-            ParticipantId = participant.ParticipantId,
+            ParticipantId = request.NhsId,
             Firstname = request.Firstname,
             Lastname = request.Lastname,
             ConsentRegistration = participant.ConsentRegistration,

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -226,16 +226,6 @@ public class ParticipantService : IParticipantService
             var entity = await _participantRepository.GetParticipantDetailsAsync(participantId);
             if (entity == null) return;
 
-            var contentfulEmailRequest = new EmailContentRequest
-            {
-                EmailName = _contentfulSettings.EmailTemplates.DeleteAccount,
-                SelectedLocale = new CultureInfo(entity.SelectedLocale ?? SelectedLocale.Default)
-            };
-
-            var contentfulEmail = await _contentfulService.GetEmailContentAsync(contentfulEmailRequest);
-
-            await _emailService.SendEmailAsync(entity.Email, contentfulEmail.EmailSubject, contentfulEmail.EmailBody);
-
             var linkedEmail = entity.Email;
             await SaveAnonymisedDemographicParticipantDataAsync(entity);
             await RemoveParticipantDataAsync(entity);
@@ -252,6 +242,17 @@ public class ParticipantService : IParticipantService
 
                 await RemoveParticipantDataAsync(linkedEntity);
             }
+
+             var contentfulEmailRequest = new EmailContentRequest
+            {
+                EmailName = _contentfulSettings.EmailTemplates.DeleteAccount,
+                SelectedLocale = new CultureInfo(entity.SelectedLocale ?? SelectedLocale.Default)
+            };
+
+            var contentfulEmail = await _contentfulService.GetEmailContentAsync(contentfulEmailRequest);
+
+            await _emailService.SendEmailAsync(entity.Email, contentfulEmail.EmailSubject, contentfulEmail.EmailBody);
+
         }
         catch (Exception ex)
         {

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -241,9 +241,17 @@ public class ParticipantService : IParticipantService
             await RemoveParticipantDataAsync(entity);
 
 
-            var linkedEntity = await GetParticipantDetailsByEmailAsync(linkedEmail);
-            if (linkedEntity == null) return;
-            await RemoveParticipantDataAsync(linkedEntity);
+            while (true)
+            {
+                var linkedEntity = await GetParticipantDetailsByEmailAsync(linkedEmail);
+
+                if (linkedEntity == null)
+                {
+                    break;
+                }
+
+                await RemoveParticipantDataAsync(linkedEntity);
+            }
         }
         catch (Exception ex)
         {
@@ -286,7 +294,16 @@ public class ParticipantService : IParticipantService
         var participantId = StripPrimaryKey(entity.Pk);
         if (entity.NhsId == null)
         {
-            await RemoveCognitoUserAsync(participantId);
+            try
+            {
+                await RemoveCognitoUserAsync(participantId);
+            }
+            catch (UserNotFoundException)
+            {
+                _logger.LogInformation(
+                    "Cognito user not found for participant {ParticipantId}.",
+                    participantId);
+            }
         }
 
         await _participantRepository.DeleteParticipantDetailsAsync(entity);

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -235,18 +235,30 @@ public class ParticipantService : IParticipantService
 
             await SaveAnonymisedDemographicParticipantDataAsync(entity);
 
-            var participants = await _participantRepository.GetAllParticipantDetailsByEmailAsync(email);
+            var deletedPks = new HashSet<string>(StringComparer.Ordinal);
 
-            var participantsToDelete = participants
-                .Append(entity)
-                .Where(x => x != null)
-                .GroupBy(x => x.Pk)
-                .Select(x => x.First())
-                .ToList();
-
-            foreach (var participant in participantsToDelete)
+            while (true)
             {
-                await RemoveParticipantDataAsync(participant);
+                var participants = await _participantRepository.GetAllParticipantDetailsByEmailAsync(email);
+
+                var participantsToDelete = participants
+                    .Append(entity)
+                    .Where(x => x != null && !deletedPks.Contains(x.Pk))
+                    .GroupBy(x => x.Pk)
+                    .Select(x => x.First())
+                    .ToList();
+
+                if (participantsToDelete.Count == 0)
+                {
+                    break;
+                }
+
+                foreach (var participant in participantsToDelete)
+                {
+                    await RemoveParticipantDataAsync(participant);
+
+                    deletedPks.Add(participant.Pk);
+                }
             }
 
             var contentfulEmailRequest = new EmailContentRequest

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -1,3 +1,10 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using Application.Constants;
 using Application.Contracts;
 using Application.Mappings.Participants;
 using Application.Models.MFA;
@@ -11,7 +18,6 @@ using Dte.Common.Exceptions.Common;
 using Dte.Common.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace Infrastructure.Services;
 

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -342,7 +342,7 @@ public class ParticipantService : IParticipantService
             EthnicGroup = entity.EthnicGroup,
             Disability = entity.Disability,
             Address = entity.Address.Clear(),
-            NHSNumber = null
+            NhsNumber = null
         };
 
         await _participantRepository.CreateAnonymisedDemographicParticipantDataAsync(anonEntity);

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -341,7 +341,8 @@ public class ParticipantService : IParticipantService
             GenderIsSameAsSexRegisteredAtBirth = entity.GenderIsSameAsSexRegisteredAtBirth,
             EthnicGroup = entity.EthnicGroup,
             Disability = entity.Disability,
-            Address = entity.Address.Clear()
+            Address = entity.Address.Clear(),
+            NHSNumber = null
         };
 
         await _participantRepository.CreateAnonymisedDemographicParticipantDataAsync(anonEntity);

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
-using Application.Constants;
 using Application.Contracts;
 using Application.Mappings.Participants;
 using Application.Models.MFA;
@@ -224,35 +223,40 @@ public class ParticipantService : IParticipantService
         try
         {
             var entity = await _participantRepository.GetParticipantDetailsAsync(participantId);
-            if (entity == null) return;
 
-            var linkedEmail = entity.Email;
-            await SaveAnonymisedDemographicParticipantDataAsync(entity);
-            await RemoveParticipantDataAsync(entity);
-
-
-            while (true)
+            if (entity == null)
             {
-                var linkedEntity = await GetParticipantDetailsByEmailAsync(linkedEmail);
-
-                if (linkedEntity == null)
-                {
-                    break;
-                }
-
-                await RemoveParticipantDataAsync(linkedEntity);
+                return;
             }
 
-             var contentfulEmailRequest = new EmailContentRequest
+            var email = entity.Email;
+            var selectedLocale = entity.SelectedLocale ?? SelectedLocale.Default;
+
+            await SaveAnonymisedDemographicParticipantDataAsync(entity);
+
+            var participants = await _participantRepository.GetAllParticipantDetailsByEmailAsync(email);
+
+            var participantsToDelete = participants
+                .Append(entity)
+                .Where(x => x != null)
+                .GroupBy(x => x.Pk)
+                .Select(x => x.First())
+                .ToList();
+
+            foreach (var participant in participantsToDelete)
+            {
+                await RemoveParticipantDataAsync(participant);
+            }
+
+            var contentfulEmailRequest = new EmailContentRequest
             {
                 EmailName = _contentfulSettings.EmailTemplates.DeleteAccount,
-                SelectedLocale = new CultureInfo(entity.SelectedLocale ?? SelectedLocale.Default)
+                SelectedLocale = new CultureInfo(selectedLocale)
             };
 
             var contentfulEmail = await _contentfulService.GetEmailContentAsync(contentfulEmailRequest);
 
-            await _emailService.SendEmailAsync(entity.Email, contentfulEmail.EmailSubject, contentfulEmail.EmailBody);
-
+            await _emailService.SendEmailAsync(email, contentfulEmail.EmailSubject, contentfulEmail.EmailBody);
         }
         catch (Exception ex)
         {

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -341,8 +341,7 @@ public class ParticipantService : IParticipantService
             GenderIsSameAsSexRegisteredAtBirth = entity.GenderIsSameAsSexRegisteredAtBirth,
             EthnicGroup = entity.EthnicGroup,
             Disability = entity.Disability,
-            Address = entity.Address.Clear(),
-            NhsNumber = null
+            Address = entity.Address.Clear()
         };
 
         await _participantRepository.CreateAnonymisedDemographicParticipantDataAsync(anonEntity);

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -1,9 +1,9 @@
-using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
+using Application.Constants;
 using Application.Contracts;
 using Application.Mappings.Participants;
 using Application.Models.MFA;

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -32,11 +32,10 @@ public class ParticipantService : IParticipantService
     private readonly IEmailService _emailService;
     private readonly IContentfulService _contentfulService;
     private readonly ContentfulSettings _contentfulSettings;
-    private readonly EmailSettings _emailSettings;
 
     public ParticipantService(IParticipantRepository participantRepository, IClock clock,
         IAmazonCognitoIdentityProvider provider, AwsSettings awsSettings,
-        ILogger<UserService> logger, EmailSettings emailSettings,
+        ILogger<UserService> logger,
         IEmailService emailService, IContentfulService contentfulService, ContentfulSettings contentfulSettings)
     {
         _participantRepository = participantRepository;
@@ -47,7 +46,6 @@ public class ParticipantService : IParticipantService
         _emailService = emailService;
         _contentfulService = contentfulService;
         _contentfulSettings = contentfulSettings;
-        _emailSettings = emailSettings;
     }
 
     private static string DeletedKey(Guid primaryKey) => $"DELETED#{primaryKey}";
@@ -89,7 +87,7 @@ public class ParticipantService : IParticipantService
             NhsId = request.NhsId,
             NhsNumber = request.NhsNumber,
             Email = request.Email,
-            ParticipantId = request.NhsId,
+            ParticipantId = participant.ParticipantId,
             Firstname = request.Firstname,
             Lastname = request.Lastname,
             ConsentRegistration = participant.ConsentRegistration,
@@ -98,32 +96,29 @@ public class ParticipantService : IParticipantService
             RemovalOfConsentRegistrationAtUtc = (DateTime?)null,
             CreatedAtUtc = _clock.Now(),
             SelectedLocale = request.SelectedLocale,
-            Stage2CompleteUtc = participant.Stage2CompleteUtc
         };
-        // check if demographic data is complete
+        
         var demographics = await _participantRepository
             .GetParticipantDemographicsAsync(participant.Pk.Replace("PARTICIPANT#", ""));
-        if (demographics.HasDemographics)
-        {
-            entity.ApplyDemographics(demographics);
-            await _participantRepository.CreateParticipantDetailsAsync(entity);
-        }
-        else if (participant.ConsentRegistration)
+
+        entity.ApplyDemographics(demographics);
+        
+        if (entity.ConsentRegistration)
         {
             // create new user with consent and deactivate the old user
             await _participantRepository.CreateParticipantDetailsAsync(entity);
-        }
+            var response = await _provider.AdminDisableUserAsync(new AdminDisableUserRequest
+            {
+                Username = participant.ParticipantId,
+                UserPoolId = _awsSettings.CognitoPoolId
+            }
+            );
 
-        var response = await _provider.AdminDisableUserAsync(new AdminDisableUserRequest
-        {
-            Username = participant.ParticipantId,
-            UserPoolId = _awsSettings.CognitoPoolId
-        }
-        );
-
-        if ((int)response.HttpStatusCode < 200 || (int)response.HttpStatusCode > 299)
-        {
-            throw new AmazonCognitoIdentityProviderException($"Unable to disable user account: {response}");
+            if ((int)response.HttpStatusCode < 200 || (int)response.HttpStatusCode > 299)
+            {
+                _logger.LogError("Unable to disable cognito user account for participantId: {participantId}. Response: {response}",
+                    participant.ParticipantId, response);
+            }
         }
     }
 
@@ -221,11 +216,11 @@ public class ParticipantService : IParticipantService
         await _participantRepository.UpdateParticipantDetailsAsync(participant);
     }
 
-    public async Task DeleteUserAsync(string participantId)
+    public async Task DeleteUserAsync(string requestParticipantId)
     {
         try
         {
-            var entity = await _participantRepository.GetParticipantDetailsAsync(participantId);
+            var entity = await _participantRepository.GetParticipantDetailsAsync(requestParticipantId);
 
             if (entity == null)
             {
@@ -239,28 +234,13 @@ public class ParticipantService : IParticipantService
 
             var deletedPks = new HashSet<string>(StringComparer.Ordinal);
 
-            while (true)
+            var participants = await _participantRepository.GetAllParticipantDetailsByEmailAsync(email);
+
+            foreach (var participant in participants)
             {
-                var participants = await _participantRepository.GetAllParticipantDetailsByEmailAsync(email);
+                await RemoveParticipantDataAsync(participant);
 
-                var participantsToDelete = participants
-                    .Append(entity)
-                    .Where(x => x != null && !deletedPks.Contains(x.Pk))
-                    .GroupBy(x => x.Pk)
-                    .Select(x => x.First())
-                    .ToList();
-
-                if (participantsToDelete.Count == 0)
-                {
-                    break;
-                }
-
-                foreach (var participant in participantsToDelete)
-                {
-                    await RemoveParticipantDataAsync(participant);
-
-                    deletedPks.Add(participant.Pk);
-                }
+                deletedPks.Add(participant.Pk);
             }
 
             var contentfulEmailRequest = new EmailContentRequest
@@ -314,16 +294,7 @@ public class ParticipantService : IParticipantService
         var participantId = StripPrimaryKey(entity.Pk);
         if (entity.NhsId == null)
         {
-            try
-            {
-                await RemoveCognitoUserAsync(participantId);
-            }
-            catch (UserNotFoundException)
-            {
-                _logger.LogInformation(
-                    "Cognito user not found for participant {ParticipantId}.",
-                    participantId);
-            }
+            await RemoveCognitoUserAsync(participantId);
         }
 
         await _participantRepository.DeleteParticipantDetailsAsync(entity);
@@ -331,11 +302,20 @@ public class ParticipantService : IParticipantService
 
     private async Task RemoveCognitoUserAsync(string username)
     {
-        await _provider.AdminDeleteUserAsync(new AdminDeleteUserRequest
+        try
         {
-            UserPoolId = _awsSettings.CognitoPoolId,
-            Username = username
-        });
+            await _provider.AdminDeleteUserAsync(new AdminDeleteUserRequest
+            {
+                UserPoolId = _awsSettings.CognitoPoolId,
+                Username = username
+            });
+        }
+        catch (UserNotFoundException ex)
+        {
+            _logger.LogError(ex,
+                "Cognito user not found for participant {ParticipantId}.",
+                username);
+        }
     }
 
     private async Task SaveAnonymisedDemographicParticipantDataAsync(ParticipantDetails entity)
@@ -359,7 +339,6 @@ public class ParticipantService : IParticipantService
         };
 
         await _participantRepository.CreateAnonymisedDemographicParticipantDataAsync(anonEntity);
-
     }
 
     public async Task<ParticipantDetails> GetParticipantDetailsAsync(string participantId)

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -97,7 +97,8 @@ public class ParticipantService : IParticipantService
             ConsentRegistrationAtUtc = participant.ConsentRegistration ? _clock.Now() : (DateTime?)null,
             RemovalOfConsentRegistrationAtUtc = (DateTime?)null,
             CreatedAtUtc = _clock.Now(),
-            SelectedLocale = request.SelectedLocale
+            SelectedLocale = request.SelectedLocale,
+            Stage2CompleteUtc = participant.Stage2CompleteUtc
         };
         // check if demographic data is complete
         var demographics = await _participantRepository

--- a/src/Infrastructure/Services/ParticipantService.cs
+++ b/src/Infrastructure/Services/ParticipantService.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
-using Amazon.CognitoIdentityProvider;
-using Amazon.CognitoIdentityProvider.Model;
-using Application.Constants;
 using Application.Contracts;
 using Application.Mappings.Participants;
 using Application.Models.MFA;
@@ -104,8 +97,8 @@ public class ParticipantService : IParticipantService
             .GetParticipantDemographicsAsync(participant.Pk.Replace("PARTICIPANT#", ""));
         if (demographics.HasDemographics)
         {
+            entity.ApplyDemographics(demographics);
             await _participantRepository.CreateParticipantDetailsAsync(entity);
-            await _participantRepository.AddDemographicsToNhsUserAsync(demographics, entity.NhsId);
         }
         else if (participant.ConsentRegistration)
         {

--- a/tests/StudyApi.Acceptance.Tests/Stubs/ParticipantRepositoryStub.cs
+++ b/tests/StudyApi.Acceptance.Tests/Stubs/ParticipantRepositoryStub.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/StudyApi.Acceptance.Tests/Stubs/ParticipantRepositoryStub.cs
+++ b/tests/StudyApi.Acceptance.Tests/Stubs/ParticipantRepositoryStub.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/StudyApi.Acceptance.Tests/Stubs/ParticipantRepositoryStub.cs
+++ b/tests/StudyApi.Acceptance.Tests/Stubs/ParticipantRepositoryStub.cs
@@ -62,13 +62,6 @@ public class ParticipantRepositoryStub : IParticipantRepository
         await Task.CompletedTask;
     }
 
-    public Task AddDemographicsToNhsUserAsync(ParticipantDemographics entity, string nhsId)
-    {
-        _participantDemographics.Add(entity);
-
-        return Task.CompletedTask;
-    }
-
     public async Task UpdateParticipantDemographicsAsync(ParticipantDemographics entity)
     {
         var item = _participantDemographics.FirstOrDefault(x => x.ParticipantId == entity.ParticipantId);

--- a/tests/StudyApi.Acceptance.Tests/Stubs/ParticipantRepositoryStub.cs
+++ b/tests/StudyApi.Acceptance.Tests/Stubs/ParticipantRepositoryStub.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Application.Contracts;
@@ -120,5 +121,19 @@ public class ParticipantRepositoryStub : IParticipantRepository
         var detail = _participantDetails.FirstOrDefault(x => x.NhsNumber == nhsNumber);
 
         return await Task.FromResult(detail);
+    }
+
+    public Task<IReadOnlyCollection<ParticipantDetails>> GetAllParticipantDetailsByEmailAsync(string email)
+    {
+        IReadOnlyCollection<ParticipantDetails> details =
+            _participantDetails
+                .Where(x =>
+                    string.Equals(
+                        x.Email,
+                        email,
+                        StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+        return Task.FromResult(details);
     }
 }


### PR DESCRIPTION
- Resolve DynamoDB mapping, storing native ParticipantId as intended instead of NhsId.
- Enrich DynamoDB with demographic info then save once, rather than saving, then overwriting with demo info.
- Catch Cognito user not found.
- On deletion, loop DynamoDB records by email until 0 remaining, aiming to resolve the existing data issue if a Participant in the same data situation attempts to delete their account.
- Move emails to the last action.