### PR TITLE
CRNCC-2718 - Re-instate fix for PRB0040556: BPoR: Volunteer Stage2Complete value getting overwritten

### DIFF
--- a/BPOR/BPOR.Registration.Stream.Handler/src/BPOR.Registration.Stream.Handler/Handlers/StreamHandler.cs
+++ b/BPOR/BPOR.Registration.Stream.Handler/src/BPOR.Registration.Stream.Handler/Handlers/StreamHandler.cs
@@ -131,16 +131,18 @@ public class StreamHandler(
     {
         var identifiers = participantMapper.ExtractIdentifiers(image);
 
-
         var targetParticipant = await participantDbContext.GetParticipantByLinkedIdentifiers(identifiers)
             .ForUpdate()
             .SingleOrDefaultAsync(cancellationToken);
-
 
         if (targetParticipant == null)
         {
             // No linked participant exists, create a new one.
             targetParticipant = participantDbContext.Participants.Add(new Participant()).Entity;
+        }
+        else
+        {
+            await participantDbContext.Entry(targetParticipant).ReloadAsync(cancellationToken);
         }
 
         return await participantMapper.Map(image, targetParticipant, cancellationToken);
@@ -158,6 +160,10 @@ public class StreamHandler(
         {
             participant = await InsertAsync(record.Dynamodb.OldImage, cancellationToken);
             await participantDbContext.SaveChangesAsync(cancellationToken);
+        }
+        else
+        {
+            await participantDbContext.Entry(participant).ReloadAsync(cancellationToken);
         }
 
         await participantMapper.Map(record.Dynamodb.NewImage, participant, cancellationToken);
@@ -177,6 +183,10 @@ public class StreamHandler(
         {
             participant = await InsertAsync(record.Dynamodb.OldImage, cancellationToken);
             await participantDbContext.SaveChangesAsync(cancellationToken);
+        }
+        else
+        {
+            await participantDbContext.Entry(participant).ReloadAsync(cancellationToken);
         }
 
         // Remove participant contact method record

--- a/BPOR/BPOR.Registration.Stream.Handler/src/BPOR.Registration.Stream.Handler/Mappers/ParticipantMapper.cs
+++ b/BPOR/BPOR.Registration.Stream.Handler/src/BPOR.Registration.Stream.Handler/Mappers/ParticipantMapper.cs
@@ -143,8 +143,20 @@ public class ParticipantMapper : IParticipantMapper
         destination.DailyLifeImpactId = _refDataService.GetDailyLifeImpactId(source.DisabilityDescription);
         destination.CreatedAt = source.CreatedAtUtc;
         destination.UpdatedAt = source.UpdatedAtUtc.HasValue ? source.UpdatedAtUtc.Value : source.CreatedAtUtc;
-        destination.Stage2CompleteUtc = source.Stage2CompleteUtc;
-        destination.IsStage2CompleteUtcBackfilled = source.IsStage2CompleteUtcBackfilled ?? false;
+
+        #region CRNCC-2718
+        // CRNCC-2718 - Only copy stage 2 complete values if the reporting database does not already hold a value
+        if (destination.Stage2CompleteUtc is null && source.Stage2CompleteUtc.HasValue)
+        {
+            destination.Stage2CompleteUtc = source.Stage2CompleteUtc;
+            destination.IsStage2CompleteUtcBackfilled = false;
+        }
+
+        if (source.IsStage2CompleteUtcBackfilled.HasValue)
+        {
+            destination.IsStage2CompleteUtcBackfilled = source.IsStage2CompleteUtcBackfilled.Value;
+        }
+        #endregion
 
         if (!destination.SourceReferences.Any(x => x.Pk == record.PK()))
         {


### PR DESCRIPTION
CRNCC-2718 - Re-instate fix for PRB0040556: BPoR: Volunteer Stage2Complete value getting overwritten which was removed from the stream handler when v1.9.0 was deployed.